### PR TITLE
Adding in linting for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Latest
+- [minor] - This creates a new rule for enums and enum props
 
 ## 7.0.1
 - [patch] - Fixed a typo in the rule name

--- a/typescript.js
+++ b/typescript.js
@@ -98,7 +98,11 @@ module.exports = {
 					},
 					{
 						selector: 'enumMember',
-						format: ['camelCase', 'UPPER_CASE'],
+						format: ['UPPER_CASE'],
+					},
+					{
+						selector: 'enum',
+						format: ['UPPER_CASE'],
 					},
 					{
 						selector: 'function',


### PR DESCRIPTION
These values were selected from a group of leads talking through what we would all agree on. This allows enums to easily be spotted out and understood compared to objects and other types