### PR TITLE
Adding __html as valid entry for  @typescript-eslint/naming-convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Latest
 
+## 7.1.1
+- [patch] - Excluded `__html` from `@typescript-eslint/naming-convention`
+
 ## 7.1.0
 - [minor] - This creates a new rule for enums and enum props
 

--- a/test/typescript/test-source.ts
+++ b/test/typescript/test-source.ts
@@ -1,1 +1,5 @@
 const x: number = 1;
+const htmlAttributes = { __html: '<style>div{color:#fff}</style>' };
+interface TestValue {
+	value: string;
+}

--- a/test/typescript/typescript.spec.js
+++ b/test/typescript/typescript.spec.js
@@ -5,22 +5,39 @@ const cli = new CLIEngine({
 	configFile: './typescript.js',
 });
 
-describe.skip('Typescript', () => {
+describe('Typescript', () => {
 	it('should catch lint', () => {
 		expect.assertions(1);
 
 		const report = cli.executeOnFiles(['test/typescript/test-source.ts']);
 
 		const errors = _.map(report.results[0].messages, (message) => {
-			return _.pick(message, 'ruleId', 'severity');
+			return _.pick(message, 'ruleId', 'severity', 'message');
 		});
 
 		expect(errors).toEqual([
 			{
+				message: 'Type number trivially inferred from a number literal, remove type annotation.',
 				ruleId: '@typescript-eslint/no-inferrable-types',
 				severity: 2,
 			},
 			{
+				message: "'x' is assigned a value but never used.",
+				ruleId: '@typescript-eslint/no-unused-vars',
+				severity: 2,
+			},
+			{
+				message: "'htmlAttributes' is assigned a value but never used.",
+				ruleId: '@typescript-eslint/no-unused-vars',
+				severity: 2,
+			},
+			{
+				message: 'Interface name `TestValue` must match the RegExp: /^I[A-Z]/u',
+				ruleId: '@typescript-eslint/naming-convention',
+				severity: 2,
+			},
+			{
+				message: "'TestValue' is defined but never used.",
 				ruleId: '@typescript-eslint/no-unused-vars',
 				severity: 2,
 			},

--- a/typescript.js
+++ b/typescript.js
@@ -115,6 +115,11 @@ module.exports = {
 						leadingUnderscore: 'allow',
 					},
 					{
+						selector: 'property',
+						format: null,
+						filter: '^__html$',
+					},
+					{
 						selector: 'parameter',
 						format: ['camelCase', 'snake_case', 'PascalCase'],
 						leadingUnderscore: 'allow',


### PR DESCRIPTION
When using `__html` in `dangerouslySetInnerHTML`,  @typescript-eslint/naming-convention fails. So adding this exclusion.